### PR TITLE
Cdps 1895: Allow null selectiveServicesFlag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/common/client/request/MilitaryRecordRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/common/client/request/MilitaryRecordRequest.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 @Schema(description = "Military record request object. Used to create or update a military record.")
-class MilitaryRecordRequest(
+data class MilitaryRecordRequest(
   @Schema(
     description = "Code identifying the war zone where the service took place.",
     example = "AFG",
@@ -63,7 +63,7 @@ class MilitaryRecordRequest(
     description = "Flag indicating if the individual was registered for UK selective military service (National Service).",
     example = "false",
   )
-  val selectiveServicesFlag: Boolean,
+  val selectiveServicesFlag: Boolean? = null,
 
   @Schema(
     description = "Code identifying the individual's military rank in the UK forces.",
@@ -82,4 +82,8 @@ class MilitaryRecordRequest(
     example = "CM",
   )
   val disciplinaryActionCode: String? = null,
-)
+) {
+  fun withDefaults(): MilitaryRecordRequest = this.copy(selectiveServicesFlag = selectiveServicesFlag ?: false)
+}
+
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/common/client/request/MilitaryRecordRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/common/client/request/MilitaryRecordRequest.kt
@@ -85,5 +85,3 @@ data class MilitaryRecordRequest(
 ) {
   fun withDefaults(): MilitaryRecordRequest = this.copy(selectiveServicesFlag = selectiveServicesFlag ?: false)
 }
-
-

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV1Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV1Resource.kt
@@ -336,7 +336,7 @@ class CorePersonRecordV1Resource(
   fun postMilitaryRecord(
     @RequestParam(required = true) @Valid @ValidPrisonerNumber prisonerNumber: String,
     @RequestBody(required = true) @Valid militaryRecordRequest: MilitaryRecordRequest,
-  ): ResponseEntity<Void> = corePersonRecordService.createMilitaryRecord(prisonerNumber, militaryRecordRequest)
+  ): ResponseEntity<Void> = corePersonRecordService.createMilitaryRecord(prisonerNumber, militaryRecordRequest.withDefaults())
 
   @PutMapping("/nationality")
   @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2Resource.kt
@@ -240,7 +240,7 @@ class CorePersonRecordV2Resource(
     @PathVariable personId: String,
     @RequestParam(required = true) militarySeq: Int,
     @RequestBody(required = true) @Valid militaryRecordRequest: MilitaryRecordRequest,
-  ): ResponseEntity<Void> = corePersonRecordService.updateMilitaryRecord(personId, militarySeq, militaryRecordRequest.withDefaults())
+  ): ResponseEntity<Void> = corePersonRecordService.updateMilitaryRecord(personId, militarySeq, militaryRecordRequest)
 
   @PostMapping("/person/{personId}/military-records")
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2Resource.kt
@@ -240,7 +240,7 @@ class CorePersonRecordV2Resource(
     @PathVariable personId: String,
     @RequestParam(required = true) militarySeq: Int,
     @RequestBody(required = true) @Valid militaryRecordRequest: MilitaryRecordRequest,
-  ): ResponseEntity<Void> = corePersonRecordService.updateMilitaryRecord(personId, militarySeq, militaryRecordRequest)
+  ): ResponseEntity<Void> = corePersonRecordService.updateMilitaryRecord(personId, militarySeq, militaryRecordRequest.withDefaults())
 
   @PostMapping("/person/{personId}/military-records")
   @ResponseStatus(HttpStatus.CREATED)
@@ -289,7 +289,7 @@ class CorePersonRecordV2Resource(
   fun postMilitaryRecord(
     @PathVariable personId: String,
     @RequestBody(required = true) @Valid militaryRecordRequest: MilitaryRecordRequest,
-  ): ResponseEntity<Void> = corePersonRecordService.createMilitaryRecord(personId, militaryRecordRequest)
+  ): ResponseEntity<Void> = corePersonRecordService.createMilitaryRecord(personId, militaryRecordRequest.withDefaults())
 
   @PutMapping("/person/{personId}/nationality")
   @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV1ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV1ResourceIntTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.OF
 import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PRISONER_NUMBER
 import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PRISONER_NUMBER_NOT_FOUND
 import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PRISON_API_NOT_FOUND_RESPONSE
+import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PrisonApiExtension.Companion.prisonApi
 import java.time.LocalDate
 
 class CorePersonRecordV1ResourceIntTest : IntegrationTestBase() {
@@ -416,6 +417,8 @@ class CorePersonRecordV1ResourceIntTest : IntegrationTestBase() {
           .bodyValue(CREATE_MILITARY_RECORD)
           .exchange()
           .expectStatus().isCreated
+
+        prisonApi.verifyDefaultsCreateMilitaryRecord()
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2ResourceIntTest.kt
@@ -1,9 +1,5 @@
 package uk.gov.justice.digital.hmpps.personintegrationapi.corepersonrecord.resource
 
-import com.github.tomakehurst.wiremock.client.WireMock.containing
-import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
-import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
-import com.github.tomakehurst.wiremock.client.WireMock.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -35,6 +31,7 @@ import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.OF
 import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PRISONER_NUMBER
 import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PRISONER_NUMBER_NOT_FOUND
 import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PRISON_API_NOT_FOUND_RESPONSE
+import uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock.PrisonApiExtension.Companion.prisonApi
 import java.time.LocalDate
 
 class CorePersonRecordV2ResourceIntTest : IntegrationTestBase() {
@@ -366,10 +363,7 @@ class CorePersonRecordV2ResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isCreated
 
-        verify(
-          postRequestedFor(urlPathEqualTo("/v2/person/$PRISONER_NUMBER/military-records"))
-            .withRequestBody(containing("selectiveServicesFlag: false")),
-        )
+        prisonApi.verifyCreateMilitaryRecord()
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2ResourceIntTest.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.personintegrationapi.corepersonrecord.resource
 
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -354,13 +358,18 @@ class CorePersonRecordV2ResourceIntTest : IntegrationTestBase() {
     inner class HappyPath {
 
       @Test
-      fun `create military record`() {
+      fun `create military record and supply default values`() {
         webTestClient.post().uri("/v2/person/$PRISONER_NUMBER/military-records")
           .contentType(MediaType.APPLICATION_JSON)
           .headers(setAuthorisation(roles = listOf(CorePersonRecordRoleConstants.CORE_PERSON_RECORD_READ_WRITE_ROLE)))
           .bodyValue(CREATE_MILITARY_RECORD)
           .exchange()
           .expectStatus().isCreated
+
+        verify(
+          postRequestedFor(urlPathEqualTo("/v2/person/$PRISONER_NUMBER/military-records"))
+            .withRequestBody(containing("selectiveServicesFlag: false")),
+        )
       }
     }
 
@@ -841,7 +850,6 @@ class CorePersonRecordV2ResourceIntTest : IntegrationTestBase() {
     val CREATE_MILITARY_RECORD = MilitaryRecordRequest(
       startDate = LocalDate.parse("2021-01-01"),
       militaryBranchCode = "NAV",
-      selectiveServicesFlag = false,
     )
 
     val UPDATE_NATIONALITY = UpdateNationality("BRIT", "French")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/CorePersonRecordV2ResourceIntTest.kt
@@ -363,7 +363,7 @@ class CorePersonRecordV2ResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isCreated
 
-        prisonApi.verifyCreateMilitaryRecord()
+        prisonApi.verifyDefaultsCreateMilitaryRecord()
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
@@ -722,7 +722,7 @@ class PrisonApiMockServer : WireMockServer(8082) {
   fun verifyCreateMilitaryRecord() {
     verify(
       postRequestedFor(urlEqualTo("/military-records"))
-        .withRequestBody(containing("selectiveServicesFlag: true"))
+        .withRequestBody(containing("selectiveServicesFlag: true")),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
@@ -2,9 +2,12 @@ package uk.gov.justice.digital.hmpps.personintegrationapi.integration.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.containing
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.put
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
@@ -713,6 +716,13 @@ class PrisonApiMockServer : WireMockServer(8082) {
       HttpStatus.NOT_FOUND,
       PRISONER_NUMBER_NOT_FOUND,
       PRISON_API_NOT_FOUND_RESPONSE.trimIndent(),
+    )
+  }
+
+  fun verifyCreateMilitaryRecord() {
+    verify(
+      postRequestedFor(urlEqualTo("/military-records"))
+        .withRequestBody(containing("selectiveServicesFlag: true"))
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
@@ -722,7 +722,7 @@ class PrisonApiMockServer : WireMockServer(8082) {
   fun verifyCreateMilitaryRecord() {
     verify(
       postRequestedFor(urlEqualTo("/military-records"))
-        .withRequestBody(containing("selectiveServicesFlag: true")),
+        .withRequestBody(containing("\"selectiveServicesFlag\":false")),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/integration/wiremock/PrisonApiMockServer.kt
@@ -719,9 +719,9 @@ class PrisonApiMockServer : WireMockServer(8082) {
     )
   }
 
-  fun verifyCreateMilitaryRecord() {
+  fun verifyDefaultsCreateMilitaryRecord() {
     verify(
-      postRequestedFor(urlEqualTo("/military-records"))
+      postRequestedFor(urlEqualTo("/api/offenders/$PRISONER_NUMBER/military-records"))
         .withRequestBody(containing("\"selectiveServicesFlag\":false")),
     )
   }


### PR DESCRIPTION
ignore commits, just look at files changed. (I was just spamming commits)

I've used a method on the request class to provide a default value. I did this instead of providing a default value immediately since if the request explicitly specifies `selectiveServicesFlag: null` rather than being missing then it would not be defaulted.

The request object is actually sent directly to the prison api and I felt it wasn't worth making a new model just to cater to this one default field.

Tested to ensure it gets defaulted.