### PR TITLE
CDPS-1978 Scale back validation on name fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/dto/request/PseudonymRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/dto/request/PseudonymRequestDto.kt
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import java.time.LocalDate
 
@@ -21,23 +20,19 @@ data class PseudonymRequestDto(
   @Schema(description = "First name", example = "John", requiredMode = REQUIRED)
   @field:Size(max = 35)
   @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z|a-z ,.'-]+$", message = "First name is not valid")
   val firstName: String,
 
   @Schema(description = "Middle name 1", example = "Middleone")
   @field:Size(max = 35)
-  @field:Pattern(regexp = "^[A-Z|a-z ,.'-]+$", message = "Middle name 1 is not valid")
   val middleName1: String? = null,
 
   @Schema(description = "Middle name 2", example = "Middletwo")
   @field:Size(max = 35)
-  @field:Pattern(regexp = "^[A-Z|a-z ,.'-]+$", message = "Middle name 2 is not valid")
   val middleName2: String? = null,
 
   @Schema(description = "Last name", example = "Smith", requiredMode = REQUIRED)
   @field:Size(max = 35)
   @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z|a-z ,.'-]+$", message = "Last name is not valid")
   val lastName: String,
 
   @Schema(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV1ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV1ResourceIntTest.kt
@@ -152,7 +152,6 @@ class PseudonymV1ResourceIntTest : IntegrationTestBase() {
       @DisplayName("Middle name 1")
       inner class MiddleName1 {
 
-
         @Test
         internal fun `first middle can not be greater than 35 characters`() {
           expectBadRequest(createRequest(middleName1 = "A".repeat(36)))
@@ -164,7 +163,6 @@ class PseudonymV1ResourceIntTest : IntegrationTestBase() {
       @Nested
       @DisplayName("Middle name 2")
       inner class MiddleName2 {
-
 
         @Test
         internal fun `second middle can not be greater than 35 characters`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV1ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV1ResourceIntTest.kt
@@ -113,12 +113,6 @@ class PseudonymV1ResourceIntTest : IntegrationTestBase() {
       @Nested
       @DisplayName("First name")
       inner class FirstName {
-        @Test
-        internal fun `first name must only contain valid characters`() {
-          expectBadRequest(createRequest(firstName = "@@@"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: firstName - First name is not valid")
-        }
 
         @Test
         internal fun `first name can not be greater than 35 characters`() {
@@ -138,12 +132,6 @@ class PseudonymV1ResourceIntTest : IntegrationTestBase() {
       @Nested
       @DisplayName("Last name")
       inner class LastName {
-        @Test
-        internal fun `last name must only contain valid characters`() {
-          expectBadRequest(createRequest(lastName = "###"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: lastName - Last name is not valid")
-        }
 
         @Test
         internal fun `last name can not be greater than 35 characters`() {
@@ -164,12 +152,6 @@ class PseudonymV1ResourceIntTest : IntegrationTestBase() {
       @DisplayName("Middle name 1")
       inner class MiddleName1 {
 
-        @Test
-        internal fun `first middle name must only contain valid characters`() {
-          expectBadRequest(createRequest(middleName1 = "@@@"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: middleName1 - Middle name 1 is not valid")
-        }
 
         @Test
         internal fun `first middle can not be greater than 35 characters`() {
@@ -183,12 +165,6 @@ class PseudonymV1ResourceIntTest : IntegrationTestBase() {
       @DisplayName("Middle name 2")
       inner class MiddleName2 {
 
-        @Test
-        internal fun `second middle name must only contain valid characters`() {
-          expectBadRequest(createRequest(middleName2 = "@@@"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: middleName2 - Middle name 2 is not valid")
-        }
 
         @Test
         internal fun `second middle can not be greater than 35 characters`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV2ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV2ResourceIntTest.kt
@@ -113,12 +113,6 @@ class PseudonymV2ResourceIntTest : IntegrationTestBase() {
       @Nested
       @DisplayName("First name")
       inner class FirstName {
-        @Test
-        internal fun `first name must only contain valid characters`() {
-          expectBadRequest(createRequest(firstName = "@@@"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: firstName - First name is not valid")
-        }
 
         @Test
         internal fun `first name can not be greater than 35 characters`() {
@@ -138,12 +132,6 @@ class PseudonymV2ResourceIntTest : IntegrationTestBase() {
       @Nested
       @DisplayName("Last name")
       inner class LastName {
-        @Test
-        internal fun `last name must only contain valid characters`() {
-          expectBadRequest(createRequest(lastName = "###"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: lastName - Last name is not valid")
-        }
 
         @Test
         internal fun `last name can not be greater than 35 characters`() {
@@ -164,12 +152,6 @@ class PseudonymV2ResourceIntTest : IntegrationTestBase() {
       @DisplayName("Middle name 1")
       inner class MiddleName1 {
 
-        @Test
-        internal fun `first middle name must only contain valid characters`() {
-          expectBadRequest(createRequest(middleName1 = "@@@"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: middleName1 - Middle name 1 is not valid")
-        }
 
         @Test
         internal fun `first middle can not be greater than 35 characters`() {
@@ -183,12 +165,6 @@ class PseudonymV2ResourceIntTest : IntegrationTestBase() {
       @DisplayName("Middle name 2")
       inner class MiddleName2 {
 
-        @Test
-        internal fun `second middle name must only contain valid characters`() {
-          expectBadRequest(createRequest(middleName2 = "@@@"))
-            .jsonPath("$.userMessage")
-            .isEqualTo("Field: middleName2 - Middle name 2 is not valid")
-        }
 
         @Test
         internal fun `second middle can not be greater than 35 characters`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV2ResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/corepersonrecord/resource/PseudonymV2ResourceIntTest.kt
@@ -152,7 +152,6 @@ class PseudonymV2ResourceIntTest : IntegrationTestBase() {
       @DisplayName("Middle name 1")
       inner class MiddleName1 {
 
-
         @Test
         internal fun `first middle can not be greater than 35 characters`() {
           expectBadRequest(createRequest(middleName1 = "A".repeat(36)))
@@ -164,7 +163,6 @@ class PseudonymV2ResourceIntTest : IntegrationTestBase() {
       @Nested
       @DisplayName("Middle name 2")
       inner class MiddleName2 {
-
 
         @Test
         internal fun `second middle can not be greater than 35 characters`() {


### PR DESCRIPTION
We discovered in dev that, when updating fields unrelated to the prisoner's name, it was nevertheless being validated during every request. As there is low-quality data in dev with nonstandard characters, this would have not been an issue in theory. However, several prisoners in preprod and prod have nonstandard name characters (from being set up via NOMIS instead of DPS, where no validation exists), and therefore we are likely to see similar issues in the wild.

The sensible solution is therefore to remove validation across the board on these fields - we already have front-end validation, whilst NOMIS has none, so this is already redundant, but as it is now actively causing issues in non-name areas, it's best to simply scale back.